### PR TITLE
Fix minor typo in notebook

### DIFF
--- a/code/Multimodal.ipynb
+++ b/code/Multimodal.ipynb
@@ -127,7 +127,7 @@
         "id": "fgpn02W-34uF"
       },
       "source": [
-        "# Using libiaries"
+        "# Using libraries"
       ]
     },
     {


### PR DESCRIPTION
## Summary
- correct `# Using libiaries` typo in Multimodal.ipynb

## Testing
- `grep -n "Using libraries" code/Multimodal.ipynb`


------
https://chatgpt.com/codex/tasks/task_e_6840093f5df8833394cb8682473f4787